### PR TITLE
Fix Typo in PowerShell Code

### DIFF
--- a/fsx-windows/workshop/9-setup-dfs/README.md
+++ b/fsx-windows/workshop/9-setup-dfs/README.md
@@ -129,7 +129,7 @@ New-DfsReplicationFolder -GroupName ${Group} -FolderName ${Folder}
 $FirstFSDnsName = "DNS Name of the source file system" # e.g. "fs-abcdef0123456789.example.com"
 $RestoredFSDnsName = "DNS Name of the restored file system" # e.g. "fs-0123456789abcdef.example.com"
 $FirstFSComputerName = (Resolve-DnsName ${FirstFSDnsName} -Type CNAME).NameHost
-$ResotredFSComputerName = (Resolve-DnsName ${RestoredFSDnsName} -Type CNAME).NameHost
+$RestoredFSComputerName = (Resolve-DnsName ${RestoredFSDnsName} -Type CNAME).NameHost
 
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

The variable `$RestoredFSComputerName` had a small typo , which would cause the steps to not work properly if copying and pasting directly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.