### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/lustre/templates/04-linux-instance.yaml
+++ b/lustre/templates/04-linux-instance.yaml
@@ -123,7 +123,7 @@ Resources:
         S3Bucket: !Sub solution-references-${AWS::Region}
         S3Key: fsx/amilookup-lin.zip
       Handler: amilookup-lin.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30
       Role: !GetAtt LambdaExecutionRole.Arn
   AmiInfo:

--- a/stg326/templates/fsxw-workshop.yaml
+++ b/stg326/templates/fsxw-workshop.yaml
@@ -413,7 +413,7 @@ Resources:
         S3Bucket: !Sub solution-references-${AWS::Region}
         S3Key: fsx/dfs/ActiveDirectoryCustomResource.zip
       Handler: ad.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30
       Role: !GetAtt LambdaExecutionRole.Arn
   ActiveDirectory:
@@ -431,7 +431,7 @@ Resources:
         S3Bucket: !Sub solution-references-${AWS::Region}
         S3Key: fsx/dfs/amilookup-win.zip
       Handler: amilookup-win.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30
       Role: !GetAtt LambdaExecutionRole.Arn
   AmiInfo:

--- a/windows/templates/04-namespace-servers.yaml
+++ b/windows/templates/04-namespace-servers.yaml
@@ -187,7 +187,7 @@ Resources:
         S3Bucket: !Sub solution-references-${AWS::Region}
         S3Key: fsx/dfs/ActiveDirectoryCustomResource.zip
       Handler: ad.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30
       Role: !GetAtt LambdaExecutionRole.Arn
   ActiveDirectory:
@@ -203,7 +203,7 @@ Resources:
         S3Bucket: !Sub solution-references-${AWS::Region}
         S3Key: fsx/dfs/amilookup-win.zip
       Handler: amilookup-win.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30
       Role: !GetAtt LambdaExecutionRole.Arn
   AmiInfo:

--- a/windows/templates/04-windows-instance.yaml
+++ b/windows/templates/04-windows-instance.yaml
@@ -214,7 +214,7 @@ Resources:
         S3Bucket: !Sub solution-references-${AWS::Region}
         S3Key: fsx/dfs/ActiveDirectoryCustomResource.zip
       Handler: ad.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30
       Role: !GetAtt LambdaExecutionRole.Arn
   ActiveDirectory:
@@ -230,7 +230,7 @@ Resources:
         S3Bucket: !Sub solution-references-${AWS::Region}
         S3Key: fsx/dfs/amilookup-win.zip
       Handler: amilookup-win.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30
       Role: !GetAtt LambdaExecutionRole.Arn
   AmiInfo:


### PR DESCRIPTION
CloudFormation templates in amazon-fsx-workshop have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.