### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/fsx-windows/workshop/templates/FSx_SetupDFSNamespaceServers.yaml
+++ b/fsx-windows/workshop/templates/FSx_SetupDFSNamespaceServers.yaml
@@ -206,7 +206,7 @@ Resources:
         S3Bucket: 'amazon-fsx-private-beta'
         S3Key: 'ActiveDirectoryCustomResource.zip'
       Handler: 'ad.handler'
-      Runtime: 'nodejs4.3'
+      Runtime: 'nodejs10.x'
       Timeout: 30
       Role: !GetAtt ActiveDirectoryRole.Arn
   ActiveDirectory:


### PR DESCRIPTION
CloudFormation templates in amazon-fsx-workshop have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.