### PR TITLE
Fixed a typo in the CIDR block selection of the CloudFormation template

### DIFF
--- a/netapp-ontap/templates/fsx-ontap-od-workshop.yaml
+++ b/netapp-ontap/templates/fsx-ontap-od-workshop.yaml
@@ -76,7 +76,7 @@ Parameters:
   VpcCidr:
     AllowedValues: 
     - 10.0.0.0/16
-    - 173.31.0.0/16
+    - 172.31.0.0/16
     - 192.168.0.0/16
     Default: 10.0.0.0/16
     Description: Select the private IPv4 CIDR for the VPC.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
List of CIDRs available for creating the VPC for the Amazon FSx for NetApp ONTAP lab included a typo of `173.31.0.0/16` which is an invalid private IP CIDR block range.  Changed this to correctly show `172.31.0.0/16`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
